### PR TITLE
Feat: 게시글 목록 조회 - 무한스크롤

### DIFF
--- a/service/article/src/main/java/sub/board/article/controller/ArticleController.java
+++ b/service/article/src/main/java/sub/board/article/controller/ArticleController.java
@@ -35,6 +35,15 @@ public class ArticleController {
         return articleService.readAll(boardId, page, pageSize);
     }
 
+    @GetMapping("/infinite-scroll")
+    public List<ArticleResponse> readAllInfiniteScroll(
+            @RequestParam Long boardId,
+            @RequestParam Long pageSize,
+            @RequestParam(required = false) Long lastArticleId
+    ) {
+        return articleService.readAllInfiniteScroll(boardId, pageSize, lastArticleId);
+    }
+
     @PatchMapping("/{articleId}")
     public ArticleResponse update(@PathVariable Long articleId, @RequestBody ArticleUpdateRequest request) {
         return articleService.update(articleId, request);

--- a/service/article/src/main/java/sub/board/article/repository/ArticleRepository.java
+++ b/service/article/src/main/java/sub/board/article/repository/ArticleRepository.java
@@ -46,4 +46,34 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
         nativeQuery = true
     )
     Long count(@Param("boardId") Long boardId, @Param("limit") Long limit);
+
+
+    @Query(
+        value = """
+                SELECT a.article_id, a.title, a.content, a.board_id, a.writer_id, a.created_at, a.modified_at
+                FROM article a
+                WHERE board_id = :boardId
+                ORDER BY article_id DESC
+                LIMIT :limit
+            """,
+        nativeQuery = true)
+    List<Article> findAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+        value = """
+                SELECT a.article_id, a.title, a.content, a.board_id, a.writer_id, a.created_at, a.modified_at
+                FROM article a
+                WHERE board_id = :boardId AND article_id < :lastArticleId
+                ORDER BY article_id DESC
+                LIMIT :limit
+            """,
+        nativeQuery = true)
+    List<Article> findAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit,
+            @Param("lastArticleId") Long lastArticleId
+    );
 }

--- a/service/article/src/main/java/sub/board/article/service/ArticleService.java
+++ b/service/article/src/main/java/sub/board/article/service/ArticleService.java
@@ -1,5 +1,6 @@
 package sub.board.article.service;
 
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +53,7 @@ public class ArticleService {
         articleRepository.deleteById(articleId);
     }
 
+    @Transactional(readOnly = true)
     public ArticlePageResponse readAll(Long boardId, Long page, Long pageSize) {
         return ArticlePageResponse.of(
             articleRepository.findAllArticle(boardId, pageSize, (page - 1) * pageSize).stream()
@@ -62,5 +64,13 @@ public class ArticleService {
                     PageLimitCalculator.calculatePageLimit(page, pageSize, 10L)
             )
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<ArticleResponse> readAllInfiniteScroll(Long boardId, Long pageSize, @Nullable Long lastArticleId) {
+        List<Article> articles = (lastArticleId == null) ?
+                articleRepository.findAllInfiniteScroll(boardId, pageSize) :
+                articleRepository.findAllInfiniteScroll(boardId, pageSize, lastArticleId);
+        return articles.stream().map(ArticleResponse::from).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Feat: 게시글 목록 조회 - 무한스크롤

- 다음 페이지 조회 시, 마지막 데이터의 Id를 통해 식별하여 다음 데이터를 가져옴
- native Query, 오버라이딩

- issue: #17 feature/article